### PR TITLE
Fix for webidl build.cpp generator error on Linux.

### DIFF
--- a/bullet/bullet.idl
+++ b/bullet/bullet.idl
@@ -512,8 +512,8 @@ interface btTypedConstraint {
 	[Const] float getParam(long num, long axis);
 	void setParam(long num, float value, long axis);
 	float getAppliedImpulse();
-	void setEnabled( bool enabled );
-	bool isEnabled();
+	void setEnabled( boolean enabled );
+	boolean isEnabled();
 };
 
 enum btConstraintParams {


### PR DESCRIPTION
On both mac and linux there is an error when trying to use webild to generate the cpp. 
Trace:
usr/share/haxe/lib/webidl/1,0,0/webidl/Generate.hx:169: characters 22-39 : Uncaught exception field access on null
/usr/share/haxe/lib/webidl/1,0,0/webidl/Generate.hx:235: characters 21-36 : Called from here
bullet/Generator.hx:28: characters 3-39 : Called from here
(unknown) : Called from here
Makefile:2: recipe for target 'genhl' failed
make: *** [genhl] Error 1
